### PR TITLE
Fase 4: Context API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,15 +3,21 @@ import { BrowserRouter } from 'react-router-dom'
 
 import './App.css'
 import Routes from './routes'
+import { AuthProvider } from './contexts/AuthContext'
+import { NotificationsProvider } from './contexts/NotificationsContext'
 
 const App = () => {
   return (
     <BrowserRouter>
-      <div className='app'>
-        <Routes />
-      </div>
+      <AuthProvider>
+        <NotificationsProvider>
+          <div className="app">
+            <Routes />
+          </div>
+        </NotificationsProvider>
+      </AuthProvider>
     </BrowserRouter>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,50 +1,37 @@
 import './index.css'
 
-import React, { useEffect, useState } from 'react'
-import { GiHamburgerMenu } from "react-icons/gi"
-import { RiLogoutBoxRLine } from "react-icons/ri"
+import React, { useState } from 'react'
+import { GiHamburgerMenu } from 'react-icons/gi'
+import { RiLogoutBoxRLine } from 'react-icons/ri'
 
 import logo from '../../images/logo.jpeg'
 
 import MobileMenu from '../Menu/MobileMenu'
 
 import { isEmployee, logoutWithConfirmation } from '../../services/auth'
-import { Notifications, addListener, removeListener } from '../../services/notifications'
+import { useNotifications } from '../../contexts/NotificationsContext'
 
 const Header = () => {
-    const [menuIsVisible, setMenuIsVisible] = useState(false)
-    const [notifications, setNotifications] = useState<Notifications>({
-        prematures: 0,
-        total: 0
-    })
+  const notifications = useNotifications()
+  const [menuIsVisible, setMenuIsVisible] = useState(false)
 
-    useEffect(() => {
-        const listenerId = addListener(data => {
-            setNotifications(data)
-        })
+  const showMenu = isEmployee()
 
-        return () => {
-            removeListener(listenerId)
-        }
-    }, [])
-    
-    const showMenu = isEmployee()
-
-    return (
-        <header className='header'>
-            <MobileMenu visible={showMenu && menuIsVisible} onClose={() => setMenuIsVisible(false)} />
-            <div className='hamburger-menu'>
-                {!!showMenu && <GiHamburgerMenu size={18} onClick={() => setMenuIsVisible(true)} />}
-                {!!notifications.total && <div className='badge' />}
-            </div>
-            <div className='logo'>
-                <img src={logo} alt="LB Consultoria" />
-            </div>
-            <div className='logout'>
-                {!showMenu && <RiLogoutBoxRLine size={18} onClick={logoutWithConfirmation} />}
-            </div>
-        </header>
-    )
+  return (
+    <header className="header">
+      <MobileMenu visible={showMenu && menuIsVisible} onClose={() => setMenuIsVisible(false)} />
+      <div className="hamburger-menu">
+        {!!showMenu && <GiHamburgerMenu size={18} onClick={() => setMenuIsVisible(true)} />}
+        {!!notifications.total && <div className="badge" />}
+      </div>
+      <div className="logo">
+        <img src={logo} alt="LB Consultoria" />
+      </div>
+      <div className="logout">
+        {!showMenu && <RiLogoutBoxRLine size={18} onClick={logoutWithConfirmation} />}
+      </div>
+    </header>
+  )
 }
 
 export default Header

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -1,28 +1,15 @@
 import './MobileMenu.css'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { IoClose } from 'react-icons/io5'
 import { RiLogoutBoxRLine } from 'react-icons/ri'
 
 import MenuItems from './MenuItems'
 import { logoutWithConfirmation } from '../../services/auth'
-import { addListener, Notifications, removeListener } from '../../services/notifications'
+import { useNotifications } from '../../contexts/NotificationsContext'
 
 const MobileMenu = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
-  const [notifications, setNotifications] = useState<Notifications>({
-    prematures: 0,
-    total: 0,
-  })
-
-  useEffect(() => {
-    const listenerId = addListener((data) => {
-      setNotifications(data)
-    })
-
-    return () => {
-      removeListener(listenerId)
-    }
-  }, [])
+  const notifications = useNotifications()
 
   return (
     <div className={`mobile-menu ${!visible ? 'mobile-menu-close' : ''}`}>

--- a/src/components/Menu/SideMenu.tsx
+++ b/src/components/Menu/SideMenu.tsx
@@ -1,53 +1,42 @@
 import './SideMenu.css'
 
-import React, { useState, useEffect } from 'react'
-import { RiLogoutBoxRLine } from "react-icons/ri"
+import React, { useState } from 'react'
+import { RiLogoutBoxRLine } from 'react-icons/ri'
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
 
 import MenuItems from './MenuItems'
 import logo from '../../images/logo.jpeg'
 
 import { logoutWithConfirmation } from '../../services/auth'
-import { Notifications, addListener, removeListener } from '../../services/notifications'
+import { useNotifications } from '../../contexts/NotificationsContext'
 
 const SideMenu = () => {
-    const ICON_SIZE = 20
+  const ICON_SIZE = 20
 
-    const [menuIsClosed, setMenuIsClosed] = useState(true)
-    const [notifications, setNotifications] = useState<Notifications>({
-        prematures: 0,
-        total: 0
-    })
+  const notifications = useNotifications()
+  const [menuIsClosed, setMenuIsClosed] = useState(true)
 
-    useEffect(() => {
-        const listenerId = addListener(data => {
-            setNotifications(data)
-        })
-
-        return () => {
-            removeListener(listenerId)
-        }
-    }, [])
-
-    return (
-        <div className={`side-menu ${menuIsClosed ? 'side-menu-close' : ''}`}>
-            <div className="logo">
-                <img src={logo} alt="LB Consultoria" />
-            </div>
-            <MenuItems notifications={notifications} />
-            <button className="logout" onClick={logoutWithConfirmation}>
-                <RiLogoutBoxRLine size={25} />
-                <span>Sair</span>
-            </button>
-            <div 
-                className='side-menu-minimize' 
-                onClick={() => { setMenuIsClosed(!menuIsClosed) }}
-            >
-                {menuIsClosed ? <BiChevronRight size={ICON_SIZE} /> : <BiChevronLeft size={ICON_SIZE} />}
-                <span>Minimizar</span>
-            </div>
-        </div>
-    )
+  return (
+    <div className={`side-menu ${menuIsClosed ? 'side-menu-close' : ''}`}>
+      <div className="logo">
+        <img src={logo} alt="LB Consultoria" />
+      </div>
+      <MenuItems notifications={notifications} />
+      <button className="logout" onClick={logoutWithConfirmation}>
+        <RiLogoutBoxRLine size={25} />
+        <span>Sair</span>
+      </button>
+      <div
+        className="side-menu-minimize"
+        onClick={() => {
+          setMenuIsClosed(!menuIsClosed)
+        }}
+      >
+        {menuIsClosed ? <BiChevronRight size={ICON_SIZE} /> : <BiChevronLeft size={ICON_SIZE} />}
+        <span>Minimizar</span>
+      </div>
+    </div>
+  )
 }
 
 export default SideMenu

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext, useState } from 'react'
+import { getToken } from '../services/auth'
+
+type AuthContextType = {
+  isLoggedIn: boolean
+  onLogin: () => void
+}
+
+const AuthContext = createContext<AuthContextType>({} as AuthContextType)
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(!!getToken())
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, onLogin: () => setIsLoggedIn(true) }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/src/contexts/NotificationsContext.tsx
+++ b/src/contexts/NotificationsContext.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { Notifications, addListener, removeListener } from '../services/notifications'
+
+const NotificationsContext = createContext<Notifications>({ prematures: 0, total: 0 })
+
+export const NotificationsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [notifications, setNotifications] = useState<Notifications>({ prematures: 0, total: 0 })
+
+  useEffect(() => {
+    const listenerId = addListener(setNotifications)
+    return () => removeListener(listenerId)
+  }, [])
+
+  return (
+    <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>
+  )
+}
+
+export const useNotifications = () => useContext(NotificationsContext)

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import { Routes as ReactRoutes, Route, Navigate, useNavigate } from 'react-router-dom'
+import React from 'react'
+import { Routes as ReactRoutes, Route, Navigate } from 'react-router-dom'
 
-import { getToken } from './services/auth'
+import { useAuth } from './contexts/AuthContext'
 
 import LoginScreen from './screens/auth/Login'
 import UpdatePasswordScreen from './screens/auth/UpdatePassword'
@@ -33,68 +33,70 @@ import AnalyticsClientScreen from './screens/analytics/client'
 import AnalyticsPerformanceScreen from './screens/analytics/performance'
 
 const Routes = () => {
-    const [isLoggedIn, setIsLoggedIn] = useState(!!getToken())
+  const { isLoggedIn } = useAuth()
 
-    const navigate = useNavigate()
+  return (
+    <ReactRoutes>
+      <Route path="/alterar-senha" element={<UpdatePasswordScreen />} />
+      <Route path="/recuperar-senha" element={<RecoveryPasswordScreen />} />
 
-    const onLogin = () => {
-        setIsLoggedIn(true)
-        navigate('/')
-    }
+      {!!isLoggedIn && (
+        <>
+          <Route path="/funcionarios" element={<EmployeeListScreen />} />
+          <Route path="/funcionarios/adicionar" element={<EmployeeFormScreen />} />
+          <Route path="/funcionarios/:userId" element={<EmployeeFormScreen />} />
 
-    return (
-        <ReactRoutes>
-            <Route path='/alterar-senha' element={<UpdatePasswordScreen onLogin={onLogin} />} />
-            <Route path='/recuperar-senha' element={<RecoveryPasswordScreen />} />
+          <Route path="/clientes" element={<ClientListScreen />} />
+          <Route path="/clientes/adicionar" element={<ClientFormScreen />} />
+          <Route path="/clientes/:userId" element={<ClientDetailsScreen />} />
+          <Route path="/clientes/:userId/editar" element={<ClientFormScreen />} />
 
-            {!!isLoggedIn && (
-                <>
-                    <Route path='/funcionarios' element={<EmployeeListScreen />} />
-                    <Route path='/funcionarios/adicionar' element={<EmployeeFormScreen />} />
-                    <Route path='/funcionarios/:userId' element={<EmployeeFormScreen />} />
+          <Route path="/clientes/:userId/propriedades" element={<RanchFormScreen />} />
+          <Route path="/clientes/:userId/propriedades/:ranchId" element={<RanchFormScreen />} />
 
-                    <Route path='/clientes' element={<ClientListScreen />} />
-                    <Route path='/clientes/adicionar' element={<ClientFormScreen />} />
-                    <Route path='/clientes/:userId' element={<ClientDetailsScreen />} />
-                    <Route path='/clientes/:userId/editar' element={<ClientFormScreen />} />
+          <Route path="/abatedouros" element={<SlaugtherhouseListScreen />} />
+          <Route path="/abatedouros/adicionar" element={<SlaugtherhouseFormScreen />} />
+          <Route path="/abatedouros/:slaughterhouseId" element={<SlaugtherhouseDetailsScreen />} />
+          <Route
+            path="/abatedouros/:slaughterhouseId/editar"
+            element={<SlaugtherhouseFormScreen />}
+          />
 
-                    <Route path='/clientes/:userId/propriedades' element={<RanchFormScreen />} />
-                    <Route path='/clientes/:userId/propriedades/:ranchId' element={<RanchFormScreen />} />
+          <Route
+            path="/abatedouros/:slaughterhouseId/unidades/adicionar"
+            element={<SlaughterhouseUnitFormScreen />}
+          />
+          <Route
+            path="/abatedouros/:slaughterhouseId/unidades/:slaughterhouseUnitId/editar"
+            element={<SlaughterhouseUnitFormScreen />}
+          />
 
-                    <Route path='/abatedouros' element={<SlaugtherhouseListScreen />} />
-                    <Route path='/abatedouros/adicionar' element={<SlaugtherhouseFormScreen />} />
-                    <Route path='/abatedouros/:slaughterhouseId' element={<SlaugtherhouseDetailsScreen />} />
-                    <Route path='/abatedouros/:slaughterhouseId/editar' element={<SlaugtherhouseFormScreen />} />
+          <Route path="/relatorios" element={<ReportListScreen />} />
+          <Route path="/relatorios/adicionar" element={<ReportFormScreen />} />
+          <Route path="/relatorios/:reportId" element={<ReportFormScreen />} />
 
-                    <Route path='/abatedouros/:slaughterhouseId/unidades/adicionar' element={<SlaughterhouseUnitFormScreen />} />
-                    <Route path='/abatedouros/:slaughterhouseId/unidades/:slaughterhouseUnitId/editar' element={<SlaughterhouseUnitFormScreen />} />
+          <Route path="/precoce" element={<PrematureListScreen />} />
+          <Route path="/precoce/adicionar" element={<PrematureFormScreen />} />
+          <Route path="/precoce/:prematureId" element={<PrematureFormScreen />} />
 
-                    <Route path='/relatorios' element={<ReportListScreen />} />
-                    <Route path='/relatorios/adicionar' element={<ReportFormScreen />} />
-                    <Route path='/relatorios/:reportId' element={<ReportFormScreen />} />
+          <Route path="/graficos" element={<AnalyticsScreen />} />
+          <Route path="/graficos/clientes" element={<AnalyticsClientScreen />} />
+          <Route path="/graficos/desempenho" element={<AnalyticsPerformanceScreen />} />
 
-                    <Route path='/precoce' element={<PrematureListScreen />} />
-                    <Route path='/precoce/adicionar' element={<PrematureFormScreen />} />
-                    <Route path='/precoce/:prematureId' element={<PrematureFormScreen />} />
+          <Route path="/relatorio/:reportId" element={<ReportViewScreen />} />
 
-                    <Route path='/graficos' element={<AnalyticsScreen />} />
-                    <Route path='/graficos/clientes' element={<AnalyticsClientScreen />} />
-                    <Route path='/graficos/desempenho' element={<AnalyticsPerformanceScreen />} />
+          <Route path="*" element={<Navigate to="/relatorios" />} />
+        </>
+      )}
 
-                    <Route path='/relatorio/:reportId' element={<ReportViewScreen />} />
-
-                    <Route path='*' element={<Navigate to='/relatorios' />} />
-                </>
-            )}
-
-            {!isLoggedIn && (
-                <>
-                    <Route path='/login' element={<LoginScreen onLogin={onLogin} />} />
-                    <Route path='*' element={<Navigate to='/login' />} />
-                </>
-            )}
-        </ReactRoutes>
-    )
+      {!isLoggedIn && (
+        <>
+          <Route path="/login" element={<LoginScreen />} />
+          <Route path="*" element={<Navigate to="/login" />} />
+        </>
+      )}
+    </ReactRoutes>
+  )
 }
 
 export default Routes

--- a/src/screens/auth/Login.tsx
+++ b/src/screens/auth/Login.tsx
@@ -2,7 +2,7 @@ import './Login.css'
 
 import React, { useState } from 'react'
 import swal from 'sweetalert'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 
 import logo from '../../images/logo.jpeg'
@@ -13,8 +13,11 @@ import TextField from '../../components/TextField'
 import { CNPJ_MASK, CPF_MASK } from '../../utils/mask'
 
 import { login } from '../../services/auth'
+import { useAuth } from '../../contexts/AuthContext'
 
-const LoginScreen = ({ onLogin }: { onLogin: () => void }) => {
+const LoginScreen = () => {
+  const { onLogin } = useAuth()
+  const navigate = useNavigate()
   const [loading, setLoading] = useState(false)
   const [useCnpjMask, setUseCnpjMask] = useState(false)
 
@@ -30,6 +33,7 @@ const LoginScreen = ({ onLogin }: { onLogin: () => void }) => {
     const { document, password } = data
     login(document, password)
       .then(onLogin)
+      .then(() => navigate('/'))
       .catch(() => {
         setLoading(false)
         swal('', 'CPF/CNPJ e/ou senha incorreto', 'error')

--- a/src/screens/auth/UpdatePassword.tsx
+++ b/src/screens/auth/UpdatePassword.tsx
@@ -12,13 +12,15 @@ import TextField from '../../components/TextField'
 
 import { updatePassword } from '../../services/auth'
 import { CNPJ_MASK, CPF_MASK } from '../../utils/mask'
+import { useAuth } from '../../contexts/AuthContext'
 
-const UpdatePasswordScreen = ({ onLogin }: { onLogin: () => void }) => {
+const UpdatePasswordScreen = () => {
+  const { onLogin } = useAuth()
+  const navigate = useNavigate()
   const [loading, setLoading] = useState(false)
   const [useCnpjMask, setUseCnpjMask] = useState(false)
 
   const [searchParams] = useSearchParams()
-  const navigate = useNavigate()
 
   const token = searchParams.get('token')
   const document = searchParams.get('document')
@@ -43,6 +45,7 @@ const UpdatePasswordScreen = ({ onLogin }: { onLogin: () => void }) => {
     updatePassword(token, document, password, confirmPassword)
       .then(() => swal('', 'Senha atualizada com sucesso.', 'success'))
       .then(onLogin)
+      .then(() => navigate('/'))
       .catch((err) => {
         setLoading(false)
         swal('', err?.response?.data ?? 'Link inválido ou expirado.', 'error')


### PR DESCRIPTION
## Resumo

Introduz dois contextos React em `src/contexts/`, eliminando prop drilling e múltiplas assinaturas redundantes ao serviço de notificações.

## AuthContext

**Problema:** `isLoggedIn` vivia como estado local em `routes.tsx`, que passava `onLogin` como prop para `LoginScreen` e `UpdatePasswordScreen`.

**Solução:**
- `AuthProvider` mantém `isLoggedIn` + `onLogin` em contexto
- `routes.tsx` simplificado: apenas `useAuth()`, sem `useState`, `useNavigate` nem `getToken`
- `Login` e `UpdatePassword` consomem `useAuth()` diretamente e gerenciam sua própria navegação com `useNavigate`

## NotificationsContext

**Problema:** `Header`, `SideMenu` e `MobileMenu` cada um subscrevia independentemente ao serviço de notificações via `addListener/removeListener`, mantendo cópias locais do estado `notifications`.

**Solução:**
- `NotificationsProvider` faz uma única assinatura no mount
- Os 3 componentes passam a consumir `useNotifications()` — sem `useEffect`, sem `addListener`, sem estado local

## Plano de migração

Esta é a **Fase 4 de 6** do plano de melhoria faseado.

- ✅ Fase 1: Fundação (tooling, tipos, qualidade de código)
- ✅ Fase 2: Testabilidade
- ✅ Fase 3: Custom Hooks
- ✅ Fase 4: Context API (esta PR)
- ⏳ Fase 5: UI/UX
- ⏳ Fase 6: Build/Performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)